### PR TITLE
Add missing pieces used in style-modules

### DIFF
--- a/csl-mlz.rnc
+++ b/csl-mlz.rnc
@@ -53,6 +53,13 @@ include "csl-repository.rnc" {
       affixes-date, font-formatting, text-case, (day | month | year)
     }
 
+  locale.court-class =
+    element cs:court-class {
+        attribute name { xsd:string },
+        attribute country { jurisdictions },
+        attribute courts { list { xsd:string } }
+    }
+
 ## Override definition of date to add use-default-locale
 rendering-element.date =
     element cs:date {

--- a/csl-mlz.rnc
+++ b/csl-mlz.rnc
@@ -403,6 +403,9 @@ rendering-element.date =
     attribute subgroup-delimiter-precedes-last {
       "contextual" | "always" | "never"
     }?,
+    attribute no-repeat {
+      list { variables+ }
+    }?,
     attribute parallel-first {
       list { variables+ }
     }?,


### PR DESCRIPTION
In the quest of https://github.com/Juris-M/citeproc-js/issues/150 I tried to validate the style module and stumbled upon missing definitions in the schema.